### PR TITLE
OCaml 4.11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,19 @@
 language: c
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+script: bash -ex .travis-docker.sh
+services:
+- docker
 env:
-  - OCAML=4.02.3
-  - OCAML=4.03.0
-script:
-  - echo "yes" | sudo add-apt-repository ppa:avsm/ppa
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq opam
-  - export OPAMYES=1
-  - opam init
-  - opam switch $OCAML
-  - eval `opam config env`
-  - opam pin add -n -k path ppx_getenv .
-  - opam install --deps-only -d -t ppx_getenv
-  - opam install -d -t -v ppx_getenv
+  global:
+  - PACKAGE="ppx_getenv"
+  matrix:
+  - DISTRO=debian-stable OCAML_VERSION=4.02
+  - DISTRO=debian-stable OCAML_VERSION=4.03
+  - DISTRO=debian-stable OCAML_VERSION=4.04
+  - DISTRO=debian-stable OCAML_VERSION=4.05
+  - DISTRO=debian-stable OCAML_VERSION=4.06
+  - DISTRO=debian-stable OCAML_VERSION=4.07
+  - DISTRO=debian-stable OCAML_VERSION=4.08
+  - DISTRO=debian-stable OCAML_VERSION=4.09
+  - DISTRO=debian-stable OCAML_VERSION=4.10
+  - DISTRO=debian-stable OCAML_VERSION=4.11.0+trunk OCAML_BETA=enable

--- a/ppx_getenv.opam
+++ b/ppx_getenv.opam
@@ -1,6 +1,5 @@
-name: "ppx_getenv"
+opam-version: "2.0"
 version: "1.2"
-opam-version: "1.2"
 maintainer: "whitequark <whitequark@whitequark.org>"
 authors: [ "whitequark <whitequark@whitequark.org>" ]
 license: "Public domain"
@@ -13,12 +12,15 @@ build: [
   "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
                          "native-dynlink=%{ocaml-native-dynlink}%"
 ]
-build-test: [
+run-test: [
   "ocamlbuild" "-classic-display" "-use-ocamlfind" "src_test/test_ppx_getenv.byte" "--"
 ]
 depends: [
-  "cppo"         {build}
-  "ppx_tools"    {>= "0.99.1"}
-  "ounit"        {test}
+  "ocaml" {>= "4.02.0"}
+  "ocamlbuild" {build}
+  "cppo" {build}
+  "cppo_ocamlbuild" {build}
+  "ppx_tools" {>= "0.99.1"}
+  "ounit" {with-test}
 ]
-available: [ocaml-version >= "4.02.0"]
+synopsis: "A sample syntax extension using OCaml's new extension points API"

--- a/ppx_getenv.opam
+++ b/ppx_getenv.opam
@@ -9,8 +9,8 @@ dev-repo: "git://github.com/whitequark/ppx_getenv.git"
 tags: [ "syntax" ]
 substs: [ "pkg/META" ]
 build: [
-  "ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
-                         "native-dynlink=%{ocaml-native-dynlink}%"
+  "ocaml" "pkg/build.ml" "native=%{ocaml:native}%"
+                         "native-dynlink=%{ocaml:native-dynlink}%"
 ]
 run-test: [
   "ocamlbuild" "-classic-display" "-use-ocamlfind" "src_test/test_ppx_getenv.byte" "--"

--- a/src/ppx_getenv.cppo.ml
+++ b/src/ppx_getenv.cppo.ml
@@ -23,9 +23,15 @@ let getenv_mapper argv =
         | (* Should have a single structure item, which is evaluation of a constant string. *)
           PStr [{ pstr_desc =
                   Pstr_eval ({ pexp_loc  = loc;
+#if OCAML_VERSION >= (4, 11, 0)
+                               pexp_desc = Pexp_constant (Pconst_string (sym, s_loc, None))}, _)}] ->
+          (* Replace with a constant string with the value from the environment. *)
+          Exp.constant ~loc (Pconst_string (getenv sym, s_loc, None))
+#else
                                pexp_desc = Pexp_constant (Pconst_string (sym, None))}, _)}] ->
           (* Replace with a constant string with the value from the environment. *)
           Exp.constant ~loc (Pconst_string (getenv sym, None))
+#endif
         | _ ->
           raise (Location.Error (
                   Location.error ~loc "[%getenv] accepts a string, e.g. [%getenv \"USER\"]"))


### PR DESCRIPTION
Currently ppx_getenv does not work with OCaml 4.11. This PR fixes the issue