### PR TITLE
Switch from OMP to ppxlib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ env:
   global:
   - PACKAGE="ppx_getenv"
   matrix:
-  - DISTRO=debian-stable OCAML_VERSION=4.02
-  - DISTRO=debian-stable OCAML_VERSION=4.03
   - DISTRO=debian-stable OCAML_VERSION=4.04
   - DISTRO=debian-stable OCAML_VERSION=4.05
   - DISTRO=debian-stable OCAML_VERSION=4.06

--- a/dune-project
+++ b/dune-project
@@ -14,7 +14,7 @@
   (synopsis "A sample syntax extension using OCaml's new extension points API")
   (tags ("syntax"))
   (depends
-    (ocaml (>= 4.02.0))
+    (ocaml (>= 4.04.0))
     (ppxlib (>= 0.9.0))
     (ounit2 :with-test)
     (odoc :with-doc)))

--- a/dune-project
+++ b/dune-project
@@ -15,6 +15,6 @@
   (tags ("syntax"))
   (depends
     (ocaml (>= 4.02.0))
-    (ocaml-migrate-parsetree (>= 1.7.0))
+    (ppxlib (>= 0.9.0))
     (ounit2 :with-test)
     (odoc :with-doc)))

--- a/ppx_getenv.opam
+++ b/ppx_getenv.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/ocaml-ppx/ppx_getenv"
 bug-reports: "https://github.com/ocaml-ppx/ppx_getenv/issues"
 depends: [
   "dune" {>= "2.0"}
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.04.0"}
   "ppxlib" {>= "0.9.0"}
   "ounit2" {with-test}
   "odoc" {with-doc}

--- a/ppx_getenv.opam
+++ b/ppx_getenv.opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/ocaml-ppx/ppx_getenv/issues"
 depends: [
   "dune" {>= "2.0"}
   "ocaml" {>= "4.02.0"}
-  "ocaml-migrate-parsetree" {>= "1.7.0"}
+  "ppxlib" {>= "0.9.0"}
   "ounit2" {with-test}
   "odoc" {with-doc}
 ]

--- a/src/dune
+++ b/src/dune
@@ -2,4 +2,4 @@
   (name ppx_getenv)
   (public_name ppx_getenv)
   (kind ppx_rewriter)
-  (libraries ocaml-migrate-parsetree))
+  (libraries ppxlib))

--- a/src/ppx_getenv.ml
+++ b/src/ppx_getenv.ml
@@ -1,19 +1,13 @@
-open Migrate_parsetree.OCaml_411.Ast
-let ocaml_version = Migrate_parsetree.Versions.ocaml_411
-
-open Ast_mapper
-open Ast_helper
-open Asttypes
-open Parsetree
+open Ppxlib
+open Ppxlib.Ast_helper
 
 let getenv s = try Sys.getenv s with Not_found -> ""
 
-let getenv_mapper _config _cookies =
-  (* Our getenv_mapper only overrides the handling of expressions in the default mapper. *)
-  { default_mapper with
-    expr = fun mapper expr ->
-      match expr with
-      (* Is this an extension node? *)
+let traverse =
+  object
+    inherit Ppxlib.Ast_traverse.map as super
+
+    method! expression = function
       | { pexp_desc =
           (* Should have name "getenv". *)
           Pexp_extension ({ txt = "getenv"; loc }, pstr); _ } ->
@@ -21,15 +15,14 @@ let getenv_mapper _config _cookies =
         | (* Should have a single structure item, which is evaluation of a constant string. *)
           PStr [{ pstr_desc =
                   Pstr_eval ({ pexp_loc  = loc;
-                               pexp_desc = Pexp_constant (Pconst_string (sym, s_loc, None)); _ }, _); _ }] ->
+                               pexp_desc = Pexp_constant (Pconst_string (sym, None)); _ }, _); _ }] ->
           (* Replace with a constant string with the value from the environment. *)
-          Exp.constant ~loc (Pconst_string (getenv sym, s_loc, None))
+          Exp.constant ~loc (Pconst_string (getenv sym, None))
         | _ ->
-          raise (Location.Error (
-                  Location.error ~loc "[%getenv] accepts a string, e.g. [%getenv \"USER\"]"))
+          Location.raise_errorf ~loc "[%%getenv] accepts a string, e.g. [%%getenv \"USER\"]"
         end
       (* Delegate to the default mapper. *)
-      | x -> default_mapper.expr mapper x;
-  }
+      | expr -> super#expression expr
+  end
 
-let () = Migrate_parsetree.Driver.register ~name:"getenv" ocaml_version getenv_mapper
+let () = Ppxlib.Driver.register_transformation ~impl:traverse#structure "ppx_getenv"

--- a/src/ppx_getenv.ml
+++ b/src/ppx_getenv.ml
@@ -3,26 +3,18 @@ open Ppxlib.Ast_helper
 
 let getenv s = try Sys.getenv s with Not_found -> ""
 
-let traverse =
-  object
-    inherit Ppxlib.Ast_traverse.map as super
+let expander ~loc ~path:_ = function
+  | (* Should have a single structure item, which is evaluation of a constant string. *)
+    PStr [{ pstr_desc =
+            Pstr_eval ({ pexp_loc  = loc;
+                         pexp_desc = Pexp_constant (Pconst_string (sym, None)); _ }, _); _ }] ->
+      (* Replace with a constant string with the value from the environment. *)
+      Exp.constant ~loc (Pconst_string (getenv sym, None))
+  | _ ->
+      Location.raise_errorf ~loc "[%%getenv] accepts a string, e.g. [%%getenv \"USER\"]"
 
-    method! expression = function
-      | { pexp_desc =
-          (* Should have name "getenv". *)
-          Pexp_extension ({ txt = "getenv"; loc }, pstr); _ } ->
-        begin match pstr with
-        | (* Should have a single structure item, which is evaluation of a constant string. *)
-          PStr [{ pstr_desc =
-                  Pstr_eval ({ pexp_loc  = loc;
-                               pexp_desc = Pexp_constant (Pconst_string (sym, None)); _ }, _); _ }] ->
-          (* Replace with a constant string with the value from the environment. *)
-          Exp.constant ~loc (Pconst_string (getenv sym, None))
-        | _ ->
-          Location.raise_errorf ~loc "[%%getenv] accepts a string, e.g. [%%getenv \"USER\"]"
-        end
-      (* Delegate to the default mapper. *)
-      | expr -> super#expression expr
-  end
+let extension =
+  Context_free.Rule.extension
+    (Extension.declare "getenv" Expression Ast_pattern.(__) expander)
 
-let () = Ppxlib.Driver.register_transformation ~impl:traverse#structure "ppx_getenv"
+let () = Ppxlib.Driver.register_transformation ~rules:[extension] "ppx_getenv"


### PR DESCRIPTION
It seems that when I made https://github.com/ocaml-ppx/ppx_getenv/pull/6 I overlooked the current plan regarding `ocaml-migrate-parsetree`. Turns out this won't be compatible with the upcoming `ocaml-migrate-parsetree.2.0.0` (see https://discuss.ocaml.org/t/ocaml-migrate-parsetree-2-0-0/5991) to be released tomorrow: https://github.com/ocaml/opam-repository/pull/16999

In view of that and the very welcome change that came with `ppxlib 0.15.0` which removed the dependencies towards `base` and `stdio` (see https://github.com/ocaml/opam-repository/pull/16965), I believe that switching to use `ppxlib` is the correct choice.

Sorry for doubling your work of maintainer.