### PR TITLE
Make ppx_getenv compatible with ppxlib.0.18.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,15 @@
 language: c
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
-script: bash -ex .travis-docker.sh
-services:
-- docker
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
+script: bash -ex .travis-opam.sh
 env:
   global:
   - PACKAGE="ppx_getenv"
   matrix:
-  - DISTRO=debian-stable OCAML_VERSION=4.04
-  - DISTRO=debian-stable OCAML_VERSION=4.05
-  - DISTRO=debian-stable OCAML_VERSION=4.06
-  - DISTRO=debian-stable OCAML_VERSION=4.07
-  - DISTRO=debian-stable OCAML_VERSION=4.08
-  - DISTRO=debian-stable OCAML_VERSION=4.09
-  - DISTRO=debian-stable OCAML_VERSION=4.10
-  - DISTRO=debian-stable OCAML_VERSION=4.11.0+trunk OCAML_BETA=enable
+  - OCAML_VERSION=4.04
+  - OCAML_VERSION=4.05
+  - OCAML_VERSION=4.06
+  - OCAML_VERSION=4.07
+  - OCAML_VERSION=4.08
+  - OCAML_VERSION=4.09
+  - OCAML_VERSION=4.10
+  - OCAML_VERSION=4.11

--- a/dune-project
+++ b/dune-project
@@ -15,6 +15,6 @@
   (tags ("syntax"))
   (depends
     (ocaml (>= 4.04.0))
-    (ppxlib (>= 0.9.0))
+    (ppxlib (>= 0.18.0))
     (ounit2 :with-test)
     (odoc :with-doc)))

--- a/ppx_getenv.opam
+++ b/ppx_getenv.opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/ocaml-ppx/ppx_getenv/issues"
 depends: [
   "dune" {>= "2.0"}
   "ocaml" {>= "4.04.0"}
-  "ppxlib" {>= "0.9.0"}
+  "ppxlib" {>= "0.18.0"}
   "ounit2" {with-test}
   "odoc" {with-doc}
 ]

--- a/src/ppx_getenv.ml
+++ b/src/ppx_getenv.ml
@@ -1,5 +1,4 @@
 open Ppxlib
-open Ppxlib.Ast_helper
 
 let getenv s = try Sys.getenv s with Not_found -> ""
 
@@ -7,9 +6,9 @@ let expander ~loc ~path:_ = function
   | (* Should have a single structure item, which is evaluation of a constant string. *)
     PStr [{ pstr_desc =
             Pstr_eval ({ pexp_loc  = loc;
-                         pexp_desc = Pexp_constant (Pconst_string (sym, None)); _ }, _); _ }] ->
+                         pexp_desc = Pexp_constant (Pconst_string (sym, _, None)); _ }, _); _ }] ->
       (* Replace with a constant string with the value from the environment. *)
-      Exp.constant ~loc (Pconst_string (getenv sym, None))
+      Ast_builder.Default.estring ~loc (getenv sym)
   | _ ->
       Location.raise_errorf ~loc "[%%getenv] accepts a string, e.g. [%%getenv \"USER\"]"
 


### PR DESCRIPTION
ppxlib.0.18.0 updates its internal AST to 4.11 resulting in a change in string constant representation. This PR makes ppx_getenv compatible with the lastest ppxlib.

You will probably want to wait for the ppxlib release to go through before merging this!